### PR TITLE
Enable meta governance for comp-like tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: trusty
+language: node_js
+node_js:
+  - '10'
+install:
+  - npm install
+script:
+  - npm run coverage
+  - cat coverage/lcov.info | coveralls

--- a/contracts/meta/MetaGovernorCOMP.sol
+++ b/contracts/meta/MetaGovernorCOMP.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+
+contract MetaGovernorCOMP {
+  using SafeMath for uint256;
+
+  /** @dev The name of this contract */
+  string public constant name = "Indexed COMP Meta Governor";
+
+  /**
+   * @dev The number of blocks subtracted from the endBlock of an external
+   * proposal to set the end block of a meta proposal.
+   */
+  uint256 public immutable votingGracePeriod;
+
+  /** @dev The address of the Indexed governance token */
+  NdxInterface public immutable ndx;
+
+
+  /** @dev The address of the COMP GovernorAlpha */
+  IGovernorAlpha public immutable compGovernor;
+
+  struct MetaProposal {
+    uint256 startBlock;
+    uint256 endBlock;
+    uint256 forVotes;
+    uint256 againstVotes;
+    bool voteSubmitted;
+    mapping(address => Receipt) receipts;
+  }
+
+  /**
+   * @dev Possible states that a meta proposal may be in
+   */
+  enum MetaProposalState {
+    Active,
+    Defeated,
+    Succeeded,
+    Executed
+  }
+
+  mapping(uint256 => MetaProposal) public proposals;
+
+  /**
+   * @dev Ballot receipt record for a voter
+   * @param hasVoted Whether or not a vote has been cast
+   * @param support Whether or not the voter supports the proposal
+   * @param votes The number of votes the voter had, which were cast
+   */
+  struct Receipt {
+    bool hasVoted;
+    bool support;
+    uint96 votes;
+  }
+
+  /**
+   * @dev An event emitted when a vote has been cast on a proposal
+   */
+  event MetaVoteCast(
+    address voter,
+    uint256 proposalId,
+    bool support,
+    uint256 votes
+  );
+
+  event ExternalVoteSubmitted(
+    uint256 proposalId,
+    bool support
+  );
+
+  constructor(address ndx_, address compGovernor_, uint256 votingGracePeriod_) public {
+    ndx = NdxInterface(ndx_);
+    compGovernor = IGovernorAlpha(compGovernor_);
+    votingGracePeriod = votingGracePeriod_;
+  }
+
+  function getReceipt(uint256 proposalId, address voter)
+    public
+    view
+    returns (Receipt memory)
+  {
+    return proposals[proposalId].receipts[voter];
+  }
+
+  function submitExternalVote(uint256 proposalId) external {
+    MetaProposal storage proposal = proposals[proposalId];
+    MetaProposalState state = _state(proposal);
+    require(
+      state == MetaProposalState.Succeeded || state == MetaProposalState.Defeated,
+      "MetaGovernorCOMP::submitExternalVote: proposal must be in Succeeded or Defeated state to execute"
+    );
+    proposal.voteSubmitted = true;
+    bool support = state == MetaProposalState.Succeeded;
+    compGovernor.castVote(proposalId, support);
+    emit ExternalVoteSubmitted(proposalId, support);
+  }
+
+  function castVote(uint256 proposalId, bool support) public {
+    return _castVote(msg.sender, proposalId, support);
+  }
+
+  function _getMetaProposal(uint256 proposalId) internal returns (MetaProposal storage) {
+    MetaProposal storage proposal = proposals[proposalId];
+    if (proposal.startBlock == 0) {
+      IGovernorAlpha.Proposal memory externalProposal = compGovernor.proposals(proposalId);
+      proposal.startBlock = externalProposal.startBlock;
+      proposal.endBlock = SafeMath.sub(externalProposal.endBlock, votingGracePeriod);
+    }
+    return proposal;
+  }
+
+  function _castVote(
+    address voter,
+    uint256 proposalId,
+    bool support
+  ) internal {
+    MetaProposal storage proposal = _getMetaProposal(proposalId);
+    require(
+      _state(proposal) == MetaProposalState.Active,
+      "MetaGovernorCOMP::_castVote: meta proposal not active"
+    );
+    Receipt storage receipt = proposal.receipts[voter];
+    require(
+      receipt.hasVoted == false,
+      "MetaGovernorCOMP::_castVote: voter already voted"
+    );
+    uint96 votes = ndx.getPriorVotes(voter, proposal.startBlock);
+
+    if (support) {
+      proposal.forVotes = SafeMath.add(proposal.forVotes, votes);
+    } else {
+      proposal.againstVotes = SafeMath.add(proposal.againstVotes, votes);
+    }
+
+    receipt.hasVoted = true;
+    receipt.support = support;
+    receipt.votes = votes;
+
+    emit MetaVoteCast(voter, proposalId, support, votes);
+  }
+
+  function state(uint256 proposalId) public view returns (MetaProposalState) {
+    MetaProposal storage proposal = proposals[proposalId];
+    return _state(proposal);
+  }
+
+  function _state(MetaProposal storage proposal) internal view returns (MetaProposalState) {
+    require(
+      proposal.startBlock != 0 && block.number > proposal.startBlock,
+      "MetaGovernorCOMP::_state: meta proposal does not exist or is not ready"
+    );
+    if (block.number <= proposal.endBlock) {
+      return MetaProposalState.Active;
+    } else if (proposal.voteSubmitted) {
+      return MetaProposalState.Executed;
+    } else if (proposal.forVotes > proposal.againstVotes) {
+      return MetaProposalState.Succeeded;
+    }
+    return MetaProposalState.Defeated;
+  }
+}
+
+
+interface IGovernorAlpha {
+  struct Proposal {
+    uint256 id;
+    address proposer;
+    uint256 eta;
+    uint256 startBlock;
+    uint256 endBlock;
+    uint256 forVotes;
+    uint256 againstVotes;
+    bool canceled;
+    bool executed;
+  }
+
+  function proposals(uint256 proposalId) external view returns (Proposal memory);
+
+  function castVote(uint256 proposalId, bool support) external;
+}
+
+
+interface NdxInterface {
+  function getPriorVotes(address account, uint256 blockNumber)
+    external
+    view
+    returns (uint96);
+}

--- a/contracts/meta/MetaGovernorCOMP.sol
+++ b/contracts/meta/MetaGovernorCOMP.sol
@@ -24,6 +24,14 @@ contract MetaGovernorCOMP {
   /** @dev The address of the COMP GovernorAlpha */
   IGovernorAlpha public immutable compGovernor;
 
+  /**
+   * @param startBlock The block at which voting begins: holders must delegate their votes prior to this block
+   * @param endBlock The block at which voting ends: votes must be cast prior to this block
+   * @param forVotes Current number of votes in favor of this proposal
+   * @param againstVotes Current number of votes in opposition to this proposal
+   * @param voteSubmitted Flag marking whether the vote has been cast on the external governor
+   * @param receipts Receipts of ballots for the entire set of voters
+   */
   struct MetaProposal {
     uint256 startBlock;
     uint256 endBlock;
@@ -79,7 +87,7 @@ contract MetaGovernorCOMP {
   }
 
   function getReceipt(uint256 proposalId, address voter)
-    public
+    external
     view
     returns (Receipt memory)
   {
@@ -99,7 +107,7 @@ contract MetaGovernorCOMP {
     emit ExternalVoteSubmitted(proposalId, support);
   }
 
-  function castVote(uint256 proposalId, bool support) public {
+  function castVote(uint256 proposalId, bool support) external {
     return _castVote(msg.sender, proposalId, support);
   }
 
@@ -143,7 +151,7 @@ contract MetaGovernorCOMP {
     emit MetaVoteCast(voter, proposalId, support, votes);
   }
 
-  function state(uint256 proposalId) public view returns (MetaProposalState) {
+  function state(uint256 proposalId) external view returns (MetaProposalState) {
     MetaProposal storage proposal = proposals[proposalId];
     return _state(proposal);
   }

--- a/contracts/meta/MetaGovernorUNI.sol
+++ b/contracts/meta/MetaGovernorUNI.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+
+contract MetaGovernorUNI {
+  using SafeMath for uint256;
+
+  /** @dev The name of this contract */
+  string public constant name = "Indexed UNI Meta Governor";
+
+  /**
+   * @dev The number of blocks subtracted from the endBlock of an external
+   * proposal to set the end block of a meta proposal.
+   */
+  uint256 public immutable votingGracePeriod;
+
+  /** @dev The address of the Indexed governance token */
+  NdxInterface public immutable ndx;
+
+
+  /** @dev The address of the UNI GovernorAlpha */
+  IGovernorAlpha public immutable uniGovernor;
+
+  struct MetaProposal {
+    uint256 startBlock;
+    uint256 endBlock;
+    uint256 forVotes;
+    uint256 againstVotes;
+    bool voteSubmitted;
+    mapping(address => Receipt) receipts;
+  }
+
+  /**
+   * @dev Possible states that a meta proposal may be in
+   */
+  enum MetaProposalState {
+    Active,
+    Defeated,
+    Succeeded,
+    Executed
+  }
+
+  mapping(uint256 => MetaProposal) public proposals;
+
+  /**
+   * @dev Ballot receipt record for a voter
+   * @param hasVoted Whether or not a vote has been cast
+   * @param support Whether or not the voter supports the proposal
+   * @param votes The number of votes the voter had, which were cast
+   */
+  struct Receipt {
+    bool hasVoted;
+    bool support;
+    uint96 votes;
+  }
+
+  /**
+   * @dev An event emitted when a vote has been cast on a proposal
+   */
+  event MetaVoteCast(
+    address voter,
+    uint256 proposalId,
+    bool support,
+    uint256 votes
+  );
+
+  event ExternalVoteSubmitted(
+    uint256 proposalId,
+    bool support
+  );
+
+  constructor(address ndx_, address uniGovernor_, uint256 votingGracePeriod_) public {
+    ndx = NdxInterface(ndx_);
+    uniGovernor = IGovernorAlpha(uniGovernor_);
+    votingGracePeriod = votingGracePeriod_;
+  }
+
+  function getReceipt(uint256 proposalId, address voter)
+    public
+    view
+    returns (Receipt memory)
+  {
+    return proposals[proposalId].receipts[voter];
+  }
+
+  function submitExternalVote(uint256 proposalId) external {
+    MetaProposal storage proposal = proposals[proposalId];
+    MetaProposalState state = _state(proposal);
+    require(
+      state == MetaProposalState.Succeeded || state == MetaProposalState.Defeated,
+      "MetaGovernorUNI::submitExternalVote: proposal must be in Succeeded or Defeated state to execute"
+    );
+    proposal.voteSubmitted = true;
+    bool support = state == MetaProposalState.Succeeded;
+    uniGovernor.castVote(proposalId, support);
+    emit ExternalVoteSubmitted(proposalId, support);
+  }
+
+  function castVote(uint256 proposalId, bool support) public {
+    return _castVote(msg.sender, proposalId, support);
+  }
+
+  function _getMetaProposal(uint256 proposalId) internal returns (MetaProposal storage) {
+    MetaProposal storage proposal = proposals[proposalId];
+    if (proposal.startBlock == 0) {
+      IGovernorAlpha.Proposal memory externalProposal = uniGovernor.proposals(proposalId);
+      proposal.startBlock = externalProposal.startBlock;
+      proposal.endBlock = SafeMath.sub(externalProposal.endBlock, votingGracePeriod);
+    }
+    return proposal;
+  }
+
+  function _castVote(
+    address voter,
+    uint256 proposalId,
+    bool support
+  ) internal {
+    MetaProposal storage proposal = _getMetaProposal(proposalId);
+    require(
+      _state(proposal) == MetaProposalState.Active,
+      "MetaGovernorUNI::_castVote: meta proposal not active"
+    );
+    Receipt storage receipt = proposal.receipts[voter];
+    require(
+      receipt.hasVoted == false,
+      "MetaGovernorUNI::_castVote: voter already voted"
+    );
+    uint96 votes = ndx.getPriorVotes(voter, proposal.startBlock);
+
+    if (support) {
+      proposal.forVotes = SafeMath.add(proposal.forVotes, votes);
+    } else {
+      proposal.againstVotes = SafeMath.add(proposal.againstVotes, votes);
+    }
+
+    receipt.hasVoted = true;
+    receipt.support = support;
+    receipt.votes = votes;
+
+    emit MetaVoteCast(voter, proposalId, support, votes);
+  }
+
+  function state(uint256 proposalId) public view returns (MetaProposalState) {
+    MetaProposal storage proposal = proposals[proposalId];
+    return _state(proposal);
+  }
+
+  function _state(MetaProposal storage proposal) internal view returns (MetaProposalState) {
+    require(
+      proposal.startBlock != 0 && block.number > proposal.startBlock,
+      "MetaGovernorUNI::_state: meta proposal does not exist or is not ready"
+    );
+    if (block.number <= proposal.endBlock) {
+      return MetaProposalState.Active;
+    } else if (proposal.voteSubmitted) {
+      return MetaProposalState.Executed;
+    } else if (proposal.forVotes > proposal.againstVotes) {
+      return MetaProposalState.Succeeded;
+    }
+    return MetaProposalState.Defeated;
+  }
+}
+
+
+interface IGovernorAlpha {
+  struct Proposal {
+    uint256 id;
+    address proposer;
+    uint256 eta;
+    uint256 startBlock;
+    uint256 endBlock;
+    uint256 forVotes;
+    uint256 againstVotes;
+    bool canceled;
+    bool executed;
+  }
+
+  function proposals(uint256 proposalId) external view returns (Proposal memory);
+
+  function castVote(uint256 proposalId, bool support) external;
+}
+
+
+interface NdxInterface {
+  function getPriorVotes(address account, uint256 blockNumber)
+    external
+    view
+    returns (uint96);
+}

--- a/contracts/meta/MetaGovernorUNI.sol
+++ b/contracts/meta/MetaGovernorUNI.sol
@@ -24,6 +24,14 @@ contract MetaGovernorUNI {
   /** @dev The address of the UNI GovernorAlpha */
   IGovernorAlpha public immutable uniGovernor;
 
+  /**
+   * @param startBlock The block at which voting begins: holders must delegate their votes prior to this block
+   * @param endBlock The block at which voting ends: votes must be cast prior to this block
+   * @param forVotes Current number of votes in favor of this proposal
+   * @param againstVotes Current number of votes in opposition to this proposal
+   * @param voteSubmitted Flag marking whether the vote has been cast on the external governor
+   * @param receipts Receipts of ballots for the entire set of voters
+   */
   struct MetaProposal {
     uint256 startBlock;
     uint256 endBlock;
@@ -79,7 +87,7 @@ contract MetaGovernorUNI {
   }
 
   function getReceipt(uint256 proposalId, address voter)
-    public
+    external
     view
     returns (Receipt memory)
   {
@@ -99,7 +107,7 @@ contract MetaGovernorUNI {
     emit ExternalVoteSubmitted(proposalId, support);
   }
 
-  function castVote(uint256 proposalId, bool support) public {
+  function castVote(uint256 proposalId, bool support) external {
     return _castVote(msg.sender, proposalId, support);
   }
 
@@ -143,7 +151,7 @@ contract MetaGovernorUNI {
     emit MetaVoteCast(voter, proposalId, support, votes);
   }
 
-  function state(uint256 proposalId) public view returns (MetaProposalState) {
+  function state(uint256 proposalId) external view returns (MetaProposalState) {
     MetaProposal storage proposal = proposals[proposalId];
     return _state(proposal);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3598,6 +3598,19 @@
         "vary": "^1"
       }
     },
+    "coveralls": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
+      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "lcov-parse": "^1.0.0",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.5",
+        "request": "^2.88.2"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -16596,6 +16609,12 @@
         "invert-kv": "^1.0.0"
       }
     },
+    "lcov-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "dev": true
+    },
     "level-codec": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
@@ -16922,6 +16941,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "prepare:team-vesting": "yarn prepare-build --contracts DelegatingVester",
     "prepare:treasury-lock": "yarn prepare-build --contracts TreasuryLock",
     "prepare:treasury-vester": "yarn prepare-build --contracts TreasuryVester",
-
     "deploy:rinkeby": "buidler --network rinkeby deploy",
     "deploy:mainnet": "buidler --network mainnet deploy",
     "deploy:ndx": "yarn prepare:ndx && yarn deploy:mainnet --tags Ndx",
@@ -36,7 +35,6 @@
     "deploy:team-vesting": "yarn prepare:team-vesting && yarn deploy:mainnet --tags DelegatingVester",
     "deploy:treasury-lock": "yarn prepare:treasury-lock && yarn deploy:mainnet --tags TreasuryLock",
     "deploy:treasury-vester": "yarn prepare:treasury-vester && yarn deploy:mainnet --tags TreasuryVester",
-
     "build": "yarn clean:build && buidler compile",
     "coverage": "buidler coverage --network coverage --solcoverjs ./.solcover.js",
     "test": "buidler test",
@@ -64,6 +62,7 @@
     "chai-as-promised": "^7.1.1",
     "chalk": "^4.1.0",
     "cli-table3": "^0.6.0",
+    "coveralls": "^3.1.0",
     "dotenv": "^8.2.0",
     "ethereum-waffle": "^3.2.1",
     "ethereumjs-wallet": "^0.6.5",

--- a/test/MetaGovernorCOMP.spec.js
+++ b/test/MetaGovernorCOMP.spec.js
@@ -1,0 +1,251 @@
+const bre = require("@nomiclabs/buidler");
+const { expect } = require('chai')
+const { constants, Contract } = require('ethers')
+const { deployments, ethers } = bre;
+
+const { expandTo18Decimals, mineBlock } = require('./utils');
+
+const governanceFixture = require('./governance.fixture');
+const { defaultAbiCoder } = require("ethers/lib/utils");
+
+async function deploy(contractName, ...args) {
+  const Factory = await ethers.getContractFactory(contractName);
+  return Factory.deploy(...args);
+}
+
+async function govSetup() {
+  const { deployer } = await getNamedAccounts();
+  const DELAY = 86400 * 2;
+  const nonce = await ethers.provider.getTransactionCount(deployer);
+
+  const { timestamp } = await ethers.provider.getBlock('latest');
+
+  const governorAlphaAddress = Contract.getContractAddress({ from: deployer, nonce: nonce + 2 });
+
+  const token = await deploy('Ndx', deployer, governorAlphaAddress, timestamp + DELAY);
+  const timelock = await deploy('Timelock', governorAlphaAddress, DELAY);
+  const governorAlpha = await deploy('GovernorAlpha', timelock.address, token.address, timestamp + (86400 * 14));
+  return {
+    token,
+    timelock,
+    governorAlpha
+  };
+}
+
+describe('MetaGovernorCOMP', () => {
+  let deployer;
+  let ndx, ndxTimelock, ndxGovernor;
+  let comp, compTimelock, compGovernor;
+  let metaGovernor
+  let testToken;
+  let signer2;
+
+  function setupTests() {
+    before(async () => {
+      ({ deployer } = await getNamedAccounts());
+      ({ token: ndx, timelock: ndxTimelock, governorAlpha: ndxGovernor } = await govSetup());
+      ({ token: comp, timelock: compTimelock, governorAlpha: compGovernor } = await govSetup());
+      testToken = await deploy('MockERC20', 'Test Token', 'Token');
+      await testToken.getFreeTokens(compTimelock.address, expandTo18Decimals(100));
+      await ndx.delegate(deployer);
+      metaGovernor = await deploy('MetaGovernorCOMP', ndx.address, compGovernor.address, 1440);
+  
+      const signatures = ['transfer(address,uint256)'];
+      const calldatas = [defaultAbiCoder.encode(['address', 'uint256'], [deployer, expandTo18Decimals(100)])];
+      const targets = [testToken.address];
+      const description = '';
+      ([x, signer2] = await ethers.getSigners());
+      const compBalance = await comp.balanceOf(deployer);
+      await comp.transfer(await signer2.getAddress(), compBalance.div(2));
+      await comp.delegate(deployer);
+      await comp.connect(signer2).delegate(metaGovernor.address);
+      await ndx.delegate(deployer);
+      await mineBlock(ethers.provider);
+      await compGovernor.propose(
+        targets,
+        [0],
+        signatures,
+        calldatas,
+        description
+      );
+      await mineBlock(ethers.provider);
+    });
+  }
+
+  describe('castVote', async () => {
+    let balance, metaProposal, proposal;
+    setupTests();
+
+    it('casts vote', async () => {
+      balance = await ndx.balanceOf(deployer);
+      await metaGovernor.castVote(1, true);
+      metaProposal = await metaGovernor.proposals( 1);
+      proposal = await compGovernor.proposals(1);
+    })
+
+    it('stores the correct start and end block', async () => {
+      expect(metaProposal.startBlock).to.eq(proposal.startBlock);
+      expect(metaProposal.endBlock).to.eq(proposal.endBlock.sub(1440));
+    })
+
+    it('records caller vote', async () => {
+      expect(metaProposal.forVotes).to.eq(balance);
+      expect(metaProposal.againstVotes).to.eq(0);
+    })
+
+    it('does not set voteSubmitted', async () => {
+      expect(metaProposal.voteSubmitted).to.be.false
+    })
+
+    it('creates receipt', async () => {
+      const receipt = await metaGovernor.getReceipt(1, deployer);
+      expect(receipt.hasVoted).to.be.true;
+      expect(receipt.support).to.be.true;
+      expect(receipt.votes).to.eq(balance);
+    })
+
+    it('rejects duplicate vote', async () => {
+      await expect(
+        metaGovernor.castVote(1, true)
+      ).to.be.revertedWith(
+        'MetaGovernorCOMP::_castVote: voter already voted'
+      )
+    })
+
+    it('rejects if proposal not active', async () => {
+      const blocks = proposal.endBlock - proposal.startBlock;
+      for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+      await expect(
+        metaGovernor.castVote(1, true)
+      ).to.be.revertedWith(
+        'MetaGovernorCOMP::_castVote: meta proposal not active'
+      )
+    })
+  })
+
+  describe('state', async () => {
+    setupTests();
+
+    it('Active', async () => {
+      await metaGovernor.castVote(1, false)
+      expect(await metaGovernor.state(1)).to.eq(0)
+    })
+
+    it('Defeated', async () => {
+      const metaProposal = await metaGovernor.proposals( 1);
+      const blocks = metaProposal.endBlock - metaProposal.startBlock;
+      for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+      expect(await metaGovernor.state(1)).to.eq(1)
+      await metaGovernor.submitExternalVote(1);
+      await comp.delegate(`0x${'00'.repeat(20)}`)
+      await compGovernor.cancel(1)
+      await comp.delegate(deployer)
+    })
+
+    it('Succeeded', async () => {
+      const signatures = ['transfer(address,uint256)'];
+      const calldatas = [defaultAbiCoder.encode(['address', 'uint256'], [deployer, expandTo18Decimals(100)])];
+      const targets = [testToken.address];
+      const description = '';
+      await compGovernor.propose(
+        targets,
+        [0],
+        signatures,
+        calldatas,
+        description
+      );
+      await mineBlock(ethers.provider)
+      await metaGovernor.castVote(2, true)
+      const metaProposal = await metaGovernor.proposals(2);
+      const blocks = metaProposal.endBlock - metaProposal.startBlock;
+      for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+      expect(await metaGovernor.state(2)).to.eq(2)
+      await comp.delegate(`0x${'00'.repeat(20)}`)
+      await compGovernor.cancel(2)
+      await comp.delegate(deployer)
+    })
+
+    it('Null / Not ready', async () => {
+      const signatures = ['transfer(address,uint256)'];
+      const calldatas = [defaultAbiCoder.encode(['address', 'uint256'], [deployer, expandTo18Decimals(100)])];
+      const targets = [testToken.address];
+      const description = '';
+      await compGovernor.propose(
+        targets,
+        [0],
+        signatures,
+        calldatas,
+        description
+      );
+      await expect(metaGovernor.state(3)).to.be.revertedWith('MetaGovernorCOMP::_state: meta proposal does not exist or is not ready');
+      await expect(metaGovernor.state(4)).to.be.revertedWith('MetaGovernorCOMP::_state: meta proposal does not exist or is not ready');
+    })
+
+    it('Executed', async () => {
+      await mineBlock(ethers.provider)
+      await metaGovernor.castVote(3, true)
+      const metaProposal = await metaGovernor.proposals(3);
+      const blocks = metaProposal.endBlock - metaProposal.startBlock;
+      for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+      await metaGovernor.submitExternalVote(3);
+      expect(await metaGovernor.state(3)).to.eq(3)
+    })
+  })
+
+  describe('submitExternalVote', async () => {
+    describe('rejection', async () => {
+      setupTests();
+
+      it('rejects if proposal does not exist', async () => {
+        await expect(
+          metaGovernor.submitExternalVote(2)
+        ).to.be.revertedWith(
+          'MetaGovernorCOMP::_state: meta proposal does not exist'
+        )
+      })
+  
+      it('rejects if proposal not ready', async () => {
+        await metaGovernor.castVote(1, true);
+        await expect(
+          metaGovernor.submitExternalVote(1)
+        ).to.be.revertedWith(
+          'MetaGovernorCOMP::submitExternalVote: proposal must be in Succeeded or Defeated state to execute'
+        )
+      })
+    })
+
+    describe('vote for', async () => {
+      setupTests();
+
+      it('submits to governor', async () => {
+        await metaGovernor.castVote(1, true);
+        const metaProposal = await metaGovernor.proposals( 1);
+        const blocks = metaProposal.endBlock - metaProposal.startBlock;
+        for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+        await metaGovernor.submitExternalVote(1);
+        const delegation = await comp.getCurrentVotes(metaGovernor.address);
+        const receipt = await compGovernor.getReceipt(1, metaGovernor.address);
+        expect(receipt.hasVoted).to.be.true;
+        expect(receipt.support).to.be.true;
+        expect(receipt.votes).to.eq(delegation);
+      })
+    })
+
+    describe('vote against', async () => {
+      setupTests();
+
+      it('submits to governor', async () => {
+        await metaGovernor.castVote(1, false);
+        const metaProposal = await metaGovernor.proposals( 1);
+        const blocks = metaProposal.endBlock - metaProposal.startBlock;
+        for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+        await metaGovernor.submitExternalVote(1);
+        const delegation = await comp.getCurrentVotes(metaGovernor.address);
+        const receipt = await compGovernor.getReceipt(1, metaGovernor.address);
+        expect(receipt.hasVoted).to.be.true;
+        expect(receipt.support).to.be.false;
+        expect(receipt.votes).to.eq(delegation);
+      })
+    })
+  })
+})

--- a/test/MetaGovernorUNI.spec.js
+++ b/test/MetaGovernorUNI.spec.js
@@ -1,0 +1,251 @@
+const bre = require("@nomiclabs/buidler");
+const { expect } = require('chai')
+const { constants, Contract } = require('ethers')
+const { deployments, ethers } = bre;
+
+const { expandTo18Decimals, mineBlock } = require('./utils');
+
+const governanceFixture = require('./governance.fixture');
+const { defaultAbiCoder } = require("ethers/lib/utils");
+
+async function deploy(contractName, ...args) {
+  const Factory = await ethers.getContractFactory(contractName);
+  return Factory.deploy(...args);
+}
+
+async function govSetup() {
+  const { deployer } = await getNamedAccounts();
+  const DELAY = 86400 * 2;
+  const nonce = await ethers.provider.getTransactionCount(deployer);
+
+  const { timestamp } = await ethers.provider.getBlock('latest');
+
+  const governorAlphaAddress = Contract.getContractAddress({ from: deployer, nonce: nonce + 2 });
+
+  const token = await deploy('Ndx', deployer, governorAlphaAddress, timestamp + DELAY);
+  const timelock = await deploy('Timelock', governorAlphaAddress, DELAY);
+  const governorAlpha = await deploy('GovernorAlpha', timelock.address, token.address, timestamp + (86400 * 14));
+  return {
+    token,
+    timelock,
+    governorAlpha
+  };
+}
+
+describe('MetaGovernorUNI', () => {
+  let deployer;
+  let ndx, ndxTimelock, ndxGovernor;
+  let uni, uniTimelock, uniGovernor;
+  let metaGovernor
+  let testToken;
+  let signer2;
+
+  function setupTests() {
+    before(async () => {
+      ({ deployer } = await getNamedAccounts());
+      ({ token: ndx, timelock: ndxTimelock, governorAlpha: ndxGovernor } = await govSetup());
+      ({ token: uni, timelock: uniTimelock, governorAlpha: uniGovernor } = await govSetup());
+      testToken = await deploy('MockERC20', 'Test Token', 'Token');
+      await testToken.getFreeTokens(uniTimelock.address, expandTo18Decimals(100));
+      await ndx.delegate(deployer);
+      metaGovernor = await deploy('MetaGovernorUNI', ndx.address, uniGovernor.address, 1440);
+  
+      const signatures = ['transfer(address,uint256)'];
+      const calldatas = [defaultAbiCoder.encode(['address', 'uint256'], [deployer, expandTo18Decimals(100)])];
+      const targets = [testToken.address];
+      const description = '';
+      ([x, signer2] = await ethers.getSigners());
+      const uniBalance = await uni.balanceOf(deployer);
+      await uni.transfer(await signer2.getAddress(), uniBalance.div(2));
+      await uni.delegate(deployer);
+      await uni.connect(signer2).delegate(metaGovernor.address);
+      await ndx.delegate(deployer);
+      await mineBlock(ethers.provider);
+      await uniGovernor.propose(
+        targets,
+        [0],
+        signatures,
+        calldatas,
+        description
+      );
+      await mineBlock(ethers.provider);
+    });
+  }
+
+  describe('castVote', async () => {
+    let balance, metaProposal, proposal;
+    setupTests();
+
+    it('casts vote', async () => {
+      balance = await ndx.balanceOf(deployer);
+      await metaGovernor.castVote(1, true);
+      metaProposal = await metaGovernor.proposals( 1);
+      proposal = await uniGovernor.proposals(1);
+    })
+
+    it('stores the correct start and end block', async () => {
+      expect(metaProposal.startBlock).to.eq(proposal.startBlock);
+      expect(metaProposal.endBlock).to.eq(proposal.endBlock.sub(1440));
+    })
+
+    it('records caller vote', async () => {
+      expect(metaProposal.forVotes).to.eq(balance);
+      expect(metaProposal.againstVotes).to.eq(0);
+    })
+
+    it('does not set voteSubmitted', async () => {
+      expect(metaProposal.voteSubmitted).to.be.false
+    })
+
+    it('creates receipt', async () => {
+      const receipt = await metaGovernor.getReceipt(1, deployer);
+      expect(receipt.hasVoted).to.be.true;
+      expect(receipt.support).to.be.true;
+      expect(receipt.votes).to.eq(balance);
+    })
+
+    it('rejects duplicate vote', async () => {
+      await expect(
+        metaGovernor.castVote(1, true)
+      ).to.be.revertedWith(
+        'MetaGovernorUNI::_castVote: voter already voted'
+      )
+    })
+
+    it('rejects if proposal not active', async () => {
+      const blocks = proposal.endBlock - proposal.startBlock;
+      for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+      await expect(
+        metaGovernor.castVote(1, true)
+      ).to.be.revertedWith(
+        'MetaGovernorUNI::_castVote: meta proposal not active'
+      )
+    })
+  })
+
+  describe('state', async () => {
+    setupTests();
+
+    it('Active', async () => {
+      await metaGovernor.castVote(1, false)
+      expect(await metaGovernor.state(1)).to.eq(0)
+    })
+
+    it('Defeated', async () => {
+      const metaProposal = await metaGovernor.proposals( 1);
+      const blocks = metaProposal.endBlock - metaProposal.startBlock;
+      for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+      expect(await metaGovernor.state(1)).to.eq(1)
+      await metaGovernor.submitExternalVote(1);
+      await uni.delegate(`0x${'00'.repeat(20)}`)
+      await uniGovernor.cancel(1)
+      await uni.delegate(deployer)
+    })
+
+    it('Succeeded', async () => {
+      const signatures = ['transfer(address,uint256)'];
+      const calldatas = [defaultAbiCoder.encode(['address', 'uint256'], [deployer, expandTo18Decimals(100)])];
+      const targets = [testToken.address];
+      const description = '';
+      await uniGovernor.propose(
+        targets,
+        [0],
+        signatures,
+        calldatas,
+        description
+      );
+      await mineBlock(ethers.provider)
+      await metaGovernor.castVote(2, true)
+      const metaProposal = await metaGovernor.proposals(2);
+      const blocks = metaProposal.endBlock - metaProposal.startBlock;
+      for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+      expect(await metaGovernor.state(2)).to.eq(2)
+      await uni.delegate(`0x${'00'.repeat(20)}`)
+      await uniGovernor.cancel(2)
+      await uni.delegate(deployer)
+    })
+
+    it('Null / Not ready', async () => {
+      const signatures = ['transfer(address,uint256)'];
+      const calldatas = [defaultAbiCoder.encode(['address', 'uint256'], [deployer, expandTo18Decimals(100)])];
+      const targets = [testToken.address];
+      const description = '';
+      await uniGovernor.propose(
+        targets,
+        [0],
+        signatures,
+        calldatas,
+        description
+      );
+      await expect(metaGovernor.state(3)).to.be.revertedWith('MetaGovernorUNI::_state: meta proposal does not exist or is not ready');
+      await expect(metaGovernor.state(4)).to.be.revertedWith('MetaGovernorUNI::_state: meta proposal does not exist or is not ready');
+    })
+
+    it('Executed', async () => {
+      await mineBlock(ethers.provider)
+      await metaGovernor.castVote(3, true)
+      const metaProposal = await metaGovernor.proposals(3);
+      const blocks = metaProposal.endBlock - metaProposal.startBlock;
+      for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+      await metaGovernor.submitExternalVote(3);
+      expect(await metaGovernor.state(3)).to.eq(3)
+    })
+  })
+
+  describe('submitExternalVote', async () => {
+    describe('rejection', async () => {
+      setupTests();
+
+      it('rejects if proposal does not exist', async () => {
+        await expect(
+          metaGovernor.submitExternalVote(2)
+        ).to.be.revertedWith(
+          'MetaGovernorUNI::_state: meta proposal does not exist'
+        )
+      })
+  
+      it('rejects if proposal not ready', async () => {
+        await metaGovernor.castVote(1, true);
+        await expect(
+          metaGovernor.submitExternalVote(1)
+        ).to.be.revertedWith(
+          'MetaGovernorUNI::submitExternalVote: proposal must be in Succeeded or Defeated state to execute'
+        )
+      })
+    })
+
+    describe('vote for', async () => {
+      setupTests();
+
+      it('submits to governor', async () => {
+        await metaGovernor.castVote(1, true);
+        const metaProposal = await metaGovernor.proposals( 1);
+        const blocks = metaProposal.endBlock - metaProposal.startBlock;
+        for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+        await metaGovernor.submitExternalVote(1);
+        const delegation = await uni.getCurrentVotes(metaGovernor.address);
+        const receipt = await uniGovernor.getReceipt(1, metaGovernor.address);
+        expect(receipt.hasVoted).to.be.true;
+        expect(receipt.support).to.be.true;
+        expect(receipt.votes).to.eq(delegation);
+      })
+    })
+
+    describe('vote against', async () => {
+      setupTests();
+
+      it('submits to governor', async () => {
+        await metaGovernor.castVote(1, false);
+        const metaProposal = await metaGovernor.proposals( 1);
+        const blocks = metaProposal.endBlock - metaProposal.startBlock;
+        for (let i = 0; i < blocks; i++) await mineBlock(ethers.provider);
+        await metaGovernor.submitExternalVote(1);
+        const delegation = await uni.getCurrentVotes(metaGovernor.address);
+        const receipt = await uniGovernor.getReceipt(1, metaGovernor.address);
+        expect(receipt.hasVoted).to.be.true;
+        expect(receipt.support).to.be.false;
+        expect(receipt.votes).to.eq(delegation);
+      })
+    })
+  })
+})


### PR DESCRIPTION
Resolves #1

This PR:
- Adds coveralls dependency and a travis.yml config to enable CI
- Adds a MetaGovernorUNI and a MetaGovernorCOMP contract

This enables the meta-governance feature discussed in the [draft for IIP 3](https://forum.indexed.finance/t/draft-iip-3-enable-meta-governance/53).

The new meta governor contracts allow NDX holders to vote by simple majority on how to cast the votes delegated to the meta governor on an external governance contract, which must be based on GovernorAlpha. Each external proposal is referred to as a "meta proposal", which has an endBlock some configurable number of blocks prior to the endBlock for the external proposal. Once the meta proposal reaches the endBlock, the meta governor will cast an affirmative vote for the external proposal if it reaches a simple majority of votes in favor, or a negative vote if it does not.
