### PR TITLE
Require votes > 0 & Add natspec docs for meta governor contracts

### DIFF
--- a/contracts/meta/MetaGovernorUNI.sol
+++ b/contracts/meta/MetaGovernorUNI.sol
@@ -5,6 +5,27 @@ pragma experimental ABIEncoderV2;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
 
+/**
+ * @title MetaGovernorUNI
+ * @dev Meta-governance contract for Uniswap's GovernorAlpha.
+ *
+ * This contract enables NDX holders to vote, by simple majority, on how to cast
+ * votes for Uniswap governance proposals.
+ *
+ * Each Uniswap proposal is wrapped as a meta proposal, which has an endBlock which
+ * ends some number of blocks prior to the end of the real proposal in order to give
+ * NDX holders time to cast meta votes prior to casting votes for the entire dao.
+ *
+ * This contract counts voting power from users the same way as the typical GovernorAlpha,
+ * which is to call getPriorVotes to check the delegation a voting account held at the time
+ * the external proposal began.
+ *
+ * Once a meta proposal has ended, it may be executed to cast votes on Uniswap. If the proposal
+ * has more votes in favor than against, it will cast votes supporting the proposal. Otherwise,
+ * it will cast votes against the proposal.
+ *
+ * This contract may not be used to submit proposals to Uniswap, only to vote on them.
+ */
 contract MetaGovernorUNI {
   using SafeMath for uint256;
 
@@ -112,6 +133,7 @@ contract MetaGovernorUNI {
   }
 
   function _getMetaProposal(uint256 proposalId) internal returns (MetaProposal storage) {
+    // Get the meta proposal if it exists, else initialize the block fields using the external proposal.
     MetaProposal storage proposal = proposals[proposalId];
     if (proposal.startBlock == 0) {
       IGovernorAlpha.Proposal memory externalProposal = uniGovernor.proposals(proposalId);
@@ -137,6 +159,10 @@ contract MetaGovernorUNI {
       "MetaGovernorUNI::_castVote: voter already voted"
     );
     uint96 votes = ndx.getPriorVotes(voter, proposal.startBlock);
+    require(
+      votes > 0,
+      "MetaGovernorUNI::_castVote: caller has no delegated NDX"
+    );
 
     if (support) {
       proposal.forVotes = SafeMath.add(proposal.forVotes, votes);

--- a/test/MetaGovernorCOMP.spec.js
+++ b/test/MetaGovernorCOMP.spec.js
@@ -76,10 +76,16 @@ describe('MetaGovernorCOMP', () => {
     let balance, metaProposal, proposal;
     setupTests();
 
+    it('rejects if caller has no votes', async () => {
+      await expect(
+        metaGovernor.connect(signer2).castVote(1, true)
+      ).to.be.revertedWith('MetaGovernorCOMP::_castVote: caller has no delegated NDX')
+    })
+
     it('casts vote', async () => {
       balance = await ndx.balanceOf(deployer);
       await metaGovernor.castVote(1, true);
-      metaProposal = await metaGovernor.proposals( 1);
+      metaProposal = await metaGovernor.proposals(1);
       proposal = await compGovernor.proposals(1);
     })
 

--- a/test/MetaGovernorUNI.spec.js
+++ b/test/MetaGovernorUNI.spec.js
@@ -76,6 +76,12 @@ describe('MetaGovernorUNI', () => {
     let balance, metaProposal, proposal;
     setupTests();
 
+    it('rejects if caller has no votes', async () => {
+      await expect(
+        metaGovernor.connect(signer2).castVote(1, true)
+      ).to.be.revertedWith('MetaGovernorUNI::_castVote: caller has no delegated NDX')
+    })
+
     it('casts vote', async () => {
       balance = await ndx.balanceOf(deployer);
       await metaGovernor.castVote(1, true);


### PR DESCRIPTION
Added assertion that caller has more than 0 votes to ensure that users can not push through a vote against a proposal without holding any NDX.

Added natspec docs explaining the contracts.